### PR TITLE
Add TEMPLATES to settings

### DIFF
--- a/dotfm/settings.py
+++ b/dotfm/settings.py
@@ -30,3 +30,43 @@ INSTALLED_APPS = [
 ROOT_URLCONF = "dotfm.urls"
 
 USE_TZ = True
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+            ],
+        },
+    },
+]
+
+# LOGGING = {
+#     "version": 1,
+#     "disable_existing_loggers": False,
+#     "formatters": {
+#         "verbose": {
+#             "format": (
+#                 "%(asctime)s [%(process)d] [%(levelname)s] "
+#                 + "pathname=%(pathname)s lineno=%(lineno)s "
+#                 + "funcname=%(funcName)s %(message)s"
+#             ),
+#         },
+#     },
+#     "handlers": {
+#         "console": {
+#             "level": "DEBUG",
+#             "class": "logging.StreamHandler",
+#             "formatter": "verbose",
+#         },
+#     },
+#     "loggers": {
+#         "": {"handlers": ["console"], "level": "DEBUG", "propagate": False},
+#         "django.server": {"handlers": ["console"], "level": "DEBUG"},
+#         "django.request": {"handlers": ["console"], "level": "DEBUG"},
+#     },
+# }


### PR DESCRIPTION
Hello @Tobi-De! The first thing I did to troubleshoot was add a `LOGGING` setting to print out what the actual 500 was. I left that (commented out) in `settings.py` just in case it's useful. Then, I saw the errors were complaining about the `TEMPLATES` setting. After I added that to `settings.py` it looks like markdown is rendering as expected. I'm going to see if I can make `coltrane` work with a missing `TEMPLATES` setting, but this should at least unblock you for now. Let me know if you run into any other issues! 👍 